### PR TITLE
Fix minSdkVersion

### DIFF
--- a/Application/build.gradle
+++ b/Application/build.gradle
@@ -38,7 +38,7 @@ android {
     buildToolsVersion "27.0.2"
 
     defaultConfig {
-        minSdkVersion 11
+        minSdkVersion 14
         targetSdkVersion 27
     }
 


### PR DESCRIPTION
Fix Android Studio 3.1 build error: 

> uses-sdk:minSdkVersion 11 cannot be smaller than version 14 declared in library [com.android.support:support-v4:27.0.2]